### PR TITLE
Error when platform-specific version of gem

### DIFF
--- a/src/bundler.rs
+++ b/src/bundler.rs
@@ -62,7 +62,7 @@ pub(crate) fn parse_gemfile(gemfile_content: String, verbose: bool) -> Gemfile {
 // Try to find platform specific version of gem
 //
 fn parse_gem_version(version_string: &str) -> (String, Option<String>) {
-    match version_string.split_once("-") {
+    match version_string.split_once('-') {
         Some((version, platform)) => (version.to_string(), Some(platform.to_string())),
         None => (version_string.to_string(), None),
     }
@@ -82,7 +82,7 @@ impl Source {
     //
     pub(crate) fn get_source(&self) -> (&str, &str, Option<&str>) {
         match &self.platform {
-            Some(platform) => (&self.name, &self.version, Some(&platform)),
+            Some(platform) => (&self.name, &self.version, Some(platform)),
             None => (&self.name, &self.version, None),
         }
     }

--- a/src/bundler.rs
+++ b/src/bundler.rs
@@ -2,8 +2,9 @@ use regex::Regex;
 
 #[derive(Debug)]
 pub(crate) struct Source {
-    pub(crate) name: String,
-    pub(crate) version: String,
+    name: String,
+    version: String,
+    platform: Option<String>,
 }
 
 pub(crate) struct Gemfile {
@@ -38,10 +39,12 @@ pub(crate) fn parse_gemfile(gemfile_content: String, verbose: bool) -> Gemfile {
 
         if gems_section && spec_regexp.is_match(line) {
             let captures = spec_regexp.captures(line).unwrap();
+            let version_info = parse_gem_version(captures.get(2).unwrap().as_str());
 
             gems.push(Source {
                 name: String::from(captures.get(1).unwrap().as_str()),
-                version: String::from(captures.get(2).unwrap().as_str()),
+                version: version_info.0,
+                platform: version_info.1
             });
         }
     }
@@ -55,11 +58,34 @@ pub(crate) fn parse_gemfile(gemfile_content: String, verbose: bool) -> Gemfile {
     result
 }
 
+//
+// Try to find platform specific version of gem
+//
+fn parse_gem_version(version_string: &str) -> (String, Option<String>) {
+    match version_string.split_once("-") {
+        Some((version, platform)) => (version.to_string(), Some(platform.to_string())),
+        None => (version_string.to_string(), None)
+    }
+}
+
 impl Gemfile {
     fn show_info(&self) {
         let length = self.gems.len();
 
         println!("\nGemfile.lock file total contains {} gems\n", length);
+    }
+}
+
+impl Source {
+    //
+    // Returns Gemfile.lock item by tuple contains (name, version, platform)
+    //
+    pub(crate) fn get_source(&self) -> (&str, &str, &str) {
+        match &self.platform {
+            Some(platform) => (&self.name, &self.version, &platform),
+            None => (&self.name, &self.version, "ruby"),
+        }
+
     }
 }
 
@@ -185,6 +211,7 @@ GEM
     choice (0.2.0)
     clavius (1.0.4)
     coderay (1.1.3)
+    nokogiri (1.16.5-arm64-darwin)
 
 PLATFORMS
   arm64-darwin-23
@@ -206,17 +233,11 @@ BUNDLED WITH
         let result = parse_gemfile(String::from(gemfile), false);
         let gems = result.gems;
 
-        assert_eq!(gems.len(), 4);
-        assert_eq!(gems.get(0).unwrap().name.as_str(), "actioncable");
-        assert_eq!(gems.get(0).unwrap().version.as_str(), "7.0.8.4");
-
-        assert_eq!(gems.get(1).unwrap().name.as_str(), "choice");
-        assert_eq!(gems.get(1).unwrap().version.as_str(), "0.2.0");
-
-        assert_eq!(gems.get(2).unwrap().name.as_str(), "clavius");
-        assert_eq!(gems.get(2).unwrap().version.as_str(), "1.0.4");
-
-        assert_eq!(gems.get(3).unwrap().name.as_str(), "coderay");
-        assert_eq!(gems.get(3).unwrap().version.as_str(), "1.1.3");
+        assert_eq!(gems.len(), 5);
+        assert_eq!(gems.get(0).unwrap().get_source(), ("actioncable", "7.0.8.4", "ruby"));
+        assert_eq!(gems.get(1).unwrap().get_source(), ("choice", "0.2.0", "ruby"));
+        assert_eq!(gems.get(2).unwrap().get_source(), ("clavius", "1.0.4", "ruby"));
+        assert_eq!(gems.get(3).unwrap().get_source(), ("coderay", "1.1.3", "ruby"));
+        assert_eq!(gems.get(4).unwrap().get_source(), ("nokogiri", "1.16.5", "arm64-darwin"));
     }
 }

--- a/src/bundler.rs
+++ b/src/bundler.rs
@@ -61,10 +61,10 @@ pub(crate) fn parse_gemfile(gemfile_content: String, verbose: bool) -> Gemfile {
 //
 // Try to find platform specific version of gem
 //
-fn parse_gem_version(version_string: &str) -> (String, Option<String>) {
-    match version_string.split_once('-') {
+fn parse_gem_version(version_str: &str) -> (String, Option<String>) {
+    match version_str.split_once('-') {
         Some((version, platform)) => (version.to_string(), Some(platform.to_string())),
-        None => (version_string.to_string(), None),
+        None => (version_str.to_string(), None),
     }
 }
 

--- a/src/bundler.rs
+++ b/src/bundler.rs
@@ -44,7 +44,7 @@ pub(crate) fn parse_gemfile(gemfile_content: String, verbose: bool) -> Gemfile {
             gems.push(Source {
                 name: String::from(captures.get(1).unwrap().as_str()),
                 version: version_info.0,
-                platform: version_info.1
+                platform: version_info.1,
             });
         }
     }
@@ -64,7 +64,7 @@ pub(crate) fn parse_gemfile(gemfile_content: String, verbose: bool) -> Gemfile {
 fn parse_gem_version(version_string: &str) -> (String, Option<String>) {
     match version_string.split_once("-") {
         Some((version, platform)) => (version.to_string(), Some(platform.to_string())),
-        None => (version_string.to_string(), None)
+        None => (version_string.to_string(), None),
     }
 }
 
@@ -80,12 +80,11 @@ impl Source {
     //
     // Returns Gemfile.lock item by tuple contains (name, version, platform)
     //
-    pub(crate) fn get_source(&self) -> (&str, &str, &str) {
+    pub(crate) fn get_source(&self) -> (&str, &str, Option<&str>) {
         match &self.platform {
-            Some(platform) => (&self.name, &self.version, &platform),
-            None => (&self.name, &self.version, "ruby"),
+            Some(platform) => (&self.name, &self.version, Some(&platform)),
+            None => (&self.name, &self.version, None),
         }
-
     }
 }
 
@@ -212,6 +211,7 @@ GEM
     clavius (1.0.4)
     coderay (1.1.3)
     nokogiri (1.16.5-arm64-darwin)
+    opentelemetry-instrumentation-net_http (0.20.0)
 
 PLATFORMS
   arm64-darwin-23
@@ -233,11 +233,27 @@ BUNDLED WITH
         let result = parse_gemfile(String::from(gemfile), false);
         let gems = result.gems;
 
-        assert_eq!(gems.len(), 5);
-        assert_eq!(gems.get(0).unwrap().get_source(), ("actioncable", "7.0.8.4", "ruby"));
-        assert_eq!(gems.get(1).unwrap().get_source(), ("choice", "0.2.0", "ruby"));
-        assert_eq!(gems.get(2).unwrap().get_source(), ("clavius", "1.0.4", "ruby"));
-        assert_eq!(gems.get(3).unwrap().get_source(), ("coderay", "1.1.3", "ruby"));
-        assert_eq!(gems.get(4).unwrap().get_source(), ("nokogiri", "1.16.5", "arm64-darwin"));
+        assert_eq!(gems.len(), 6);
+        assert_eq!(
+            gems.get(0).unwrap().get_source(),
+            ("actioncable", "7.0.8.4", None)
+        );
+        assert_eq!(gems.get(1).unwrap().get_source(), ("choice", "0.2.0", None));
+        assert_eq!(
+            gems.get(2).unwrap().get_source(),
+            ("clavius", "1.0.4", None)
+        );
+        assert_eq!(
+            gems.get(3).unwrap().get_source(),
+            ("coderay", "1.1.3", None)
+        );
+        assert_eq!(
+            gems.get(4).unwrap().get_source(),
+            ("nokogiri", "1.16.5", Some("arm64-darwin"))
+        );
+        assert_eq!(
+            gems.get(5).unwrap().get_source(),
+            ("opentelemetry-instrumentation-net_http", "0.20.0", None)
+        );
     }
 }

--- a/src/gem.rs
+++ b/src/gem.rs
@@ -40,7 +40,7 @@ type GemfileItem<'a> = (&'a str, &'a str, Option<&'a str>);
 /// If all ok, this function returns Gemspec struct, which serializable
 /// to bom.json format
 ///
-pub(crate) async fn get_gem<'a>(gem_source: GemfileItem<'a>) -> Result<Gemspec> {
+pub(crate) async fn get_gem(gem_source: GemfileItem<'_>) -> Result<Gemspec> {
     let (name, version, _) = gem_source;
     let url = format!("https://rubygems.org/api/v1/versions/{name}.json");
 
@@ -84,7 +84,7 @@ pub(crate) async fn get_gem<'a>(gem_source: GemfileItem<'a>) -> Result<Gemspec> 
 //
 // Try to find current version gem information from rubygems response
 //
-fn find_version_gem<'a>(gem_data: &str, gem_source: GemfileItem<'a>) -> Option<GemspecResponse> {
+fn find_version_gem(gem_data: &str, gem_source: GemfileItem) -> Option<GemspecResponse> {
     let (_, version, platform) = gem_source;
     if let Ok(gem_list) = serde_json::from_str::<Vec<GemspecResponse>>(gem_data) {
         return gem_list

--- a/src/gem.rs
+++ b/src/gem.rs
@@ -84,7 +84,7 @@ fn find_version_gem(gem_data: &str, version: &str) -> Option<GemspecResponse> {
     if let Ok(gem_list) = serde_json::from_str::<Vec<GemspecResponse>>(gem_data) {
         return gem_list
             .iter()
-            .find(|item| -> bool { item.number == version })
+            .find(|item| { item.number == version })
             .cloned();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,10 @@ type GemspecResultsPartition = (
 );
 async fn fetch_gems_info(specs: Vec<bundler::Source>, verbose: bool) -> Vec<gem::Gemspec> {
     let gem_specs_results = stream::iter(specs)
-        .map(|source| async move { gem::get_gem(&source.name, &source.version).await })
+        .map(|source| async move {
+            let source_info = source.get_source();
+            gem::get_gem(source_info.0, source_info.1).await
+        })
         .buffer_unordered(CONCURRENT_REQUESTS)
         .collect::<Vec<Result<gem::Gemspec, anyhow::Error>>>()
         .await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ async fn fetch_gems_info(specs: Vec<bundler::Source>, verbose: bool) -> Vec<gem:
     let gem_specs_results = stream::iter(specs)
         .map(|source| async move {
             let source_info = source.get_source();
-            gem::get_gem(source_info.0, source_info.1).await
+            gem::get_gem(source_info).await
         })
         .buffer_unordered(CONCURRENT_REQUESTS)
         .collect::<Vec<Result<gem::Gemspec, anyhow::Error>>>()


### PR DESCRIPTION
The error has been found. The version is not detected for platform-dependent packages. For example:
```
Could not find version 1.16.5-arm64-darwin for gem nokogiri
Could not find version 1.16.5-x86_64-darwin for gem nokogiri
```
<img width="636" alt="bug_cyclonedx_rs_gem" src="https://github.com/user-attachments/assets/48eb9b9a-ebe4-49d5-8ba7-afd0bd40c76e">

This is due to the fact that when selecting a version from the API response of rubygems.org, platform-specific gem packages were not taken into account.