### PR TITLE
Retry failed requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "async-trait"
+version = "0.1.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +233,9 @@ dependencies = [
  "quick-xml",
  "regex",
  "reqwest",
+ "reqwest-conditional-middleware",
+ "reqwest-middleware",
+ "reqwest-retry",
  "serde",
  "serde_json",
  "tokio",
@@ -385,8 +399,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -543,6 +559,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +608,16 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -696,6 +734,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,6 +867,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +947,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest-conditional-middleware"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1663d9d4fbb6e3900f91455d6d7833301c91ae3c7fc6e116fd7acd40e478a93"
+dependencies = [
+ "async-trait",
+ "http",
+ "reqwest",
+ "reqwest-middleware",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "serde",
+ "thiserror",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-retry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a83df1aaec00176d0fabb65dea13f832d2a446ca99107afc17c5d2d4981221d0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "getrandom",
+ "http",
+ "hyper",
+ "parking_lot",
+ "reqwest",
+ "reqwest-middleware",
+ "retry-policies",
+ "tokio",
+ "tracing",
+ "wasm-timer",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
+dependencies = [
+ "rand",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,6 +1052,12 @@ checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -1072,6 +1207,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1170,7 +1325,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1324,6 +1491,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,6 +1514,28 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,11 +233,11 @@ dependencies = [
  "quick-xml",
  "regex",
  "reqwest",
- "reqwest-conditional-middleware",
  "reqwest-middleware",
  "reqwest-retry",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "uuid",
 ]
@@ -944,18 +944,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
-]
-
-[[package]]
-name = "reqwest-conditional-middleware"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1663d9d4fbb6e3900f91455d6d7833301c91ae3c7fc6e116fd7acd40e478a93"
-dependencies = [
- "async-trait",
- "http",
- "reqwest",
- "reqwest-middleware",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ tokio = { version = "1.38.0", features = ["macros", "rt"] }
 futures = "0.3"
 uuid = { version = "1.8.0", features = ["v4", "fast-rng"] }
 reqwest-retry = "0.6.1"
-reqwest-conditional-middleware = "0.3.0"
 reqwest-middleware = "0.3.3"
+thiserror = "1.0.63"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ serde_json = { version = "1.0.117", features = ["std"] }
 tokio = { version = "1.38.0", features = ["macros", "rt"] }
 futures = "0.3"
 uuid = { version = "1.8.0", features = ["v4", "fast-rng"] }
+reqwest-retry = "0.6.1"
+reqwest-conditional-middleware = "0.3.0"
+reqwest-middleware = "0.3.3"

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,6 +4,10 @@ use reqwest_retry::{default_on_request_failure, policies::ExponentialBackoff, Re
 use reqwest::{Response, Client};
 use reqwest_middleware::{ClientBuilder, Result as MiddlewareResult};
 
+///
+/// Strategy for retry all failed requests, except 404
+/// (gem not found)
+///
 struct RetryAllExcept404;
 impl RetryableStrategy for RetryAllExcept404 {
     fn handle(&self, res: &MiddlewareResult<Response>) -> Option<Retryable> {
@@ -16,6 +20,9 @@ impl RetryableStrategy for RetryAllExcept404 {
     }
 }
 
+///
+/// Configure reqwest http client with custom retry strategy
+///
 pub(crate) fn get_client() -> Result<ClientWithMiddleware> {
     let http = Client::builder()
         .redirect(reqwest::redirect::Policy::none())

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,33 @@
+use anyhow::Result;
+use reqwest_middleware::ClientWithMiddleware;
+use reqwest_retry::{default_on_request_failure, policies::ExponentialBackoff, Retryable, RetryableStrategy, RetryTransientMiddleware};
+use reqwest::{Response, Client};
+use reqwest_middleware::{ClientBuilder, Result as MiddlewareResult};
+
+struct RetryAllExcept404;
+impl RetryableStrategy for RetryAllExcept404 {
+    fn handle(&self, res: &MiddlewareResult<Response>) -> Option<Retryable> {
+        match res {
+            // don't repeat if gem not found
+            Ok(success) if success.status() == 404 => None,
+            Ok(_) => Some(Retryable::Transient),
+            Err(error) => default_on_request_failure(error),
+        }
+    }
+}
+
+pub(crate) fn get_client() -> Result<ClientWithMiddleware> {
+    let http = Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()?;
+    let retry_policy = ExponentialBackoff::builder().build_with_max_retries(3);
+    let retry_middleware = RetryTransientMiddleware::new_with_policy_and_strategy(
+        retry_policy,
+        RetryAllExcept404,
+    );
+    let client = ClientBuilder::new(http)
+        .with(retry_middleware)
+        .build();
+
+    Ok(client)
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,8 +1,11 @@
 use anyhow::Result;
+use reqwest::{Client, Response};
 use reqwest_middleware::ClientWithMiddleware;
-use reqwest_retry::{default_on_request_failure, policies::ExponentialBackoff, Retryable, RetryableStrategy, RetryTransientMiddleware};
-use reqwest::{Response, Client};
 use reqwest_middleware::{ClientBuilder, Result as MiddlewareResult};
+use reqwest_retry::{
+    default_on_request_failure, policies::ExponentialBackoff, RetryTransientMiddleware, Retryable,
+    RetryableStrategy,
+};
 
 ///
 /// Strategy for retry all failed requests, except 404
@@ -28,13 +31,9 @@ pub(crate) fn get_client() -> Result<ClientWithMiddleware> {
         .redirect(reqwest::redirect::Policy::none())
         .build()?;
     let retry_policy = ExponentialBackoff::builder().build_with_max_retries(3);
-    let retry_middleware = RetryTransientMiddleware::new_with_policy_and_strategy(
-        retry_policy,
-        RetryAllExcept404,
-    );
-    let client = ClientBuilder::new(http)
-        .with(retry_middleware)
-        .build();
+    let retry_middleware =
+        RetryTransientMiddleware::new_with_policy_and_strategy(retry_policy, RetryAllExcept404);
+    let client = ClientBuilder::new(http).with(retry_middleware).build();
 
     Ok(client)
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,18 +5,18 @@ use thiserror::Error;
 /// 
 #[derive(Error, Debug)]
 pub(crate) enum FetchPackageError {
-    #[error("Could not send request for `{0}` for gem `{1}`")]
+    #[error("Could not send request for gem {0} version {1}")]
     SendRequestError(String, String),
-    #[error("Could not receive response text for `{0}` for gem `{1}`")]
+    #[error("Could not receive response text for {0} for gem {1}")]
     ResponseTextError(String, String),
-    #[error("Could not find version `{0}` for gem `{1}`")]
+    #[error("Could not find version {0} for gem {1}")]
     VersionNotFound(String, String),
-    #[error("Gem not found: `{0}`, version `{1}`")]
+    #[error("Gem not found: {0}, version {1}")]
     PackageNotFound(String, String),
-    #[error("Client error occurred for gem `{0}`, version `{1}`")]
+    #[error("Client error occurred for gem {0}, version {1}")]
     ClientError(String, String),
-    #[error("Server error occurred for gem `{0}`, version `{1}`")]
+    #[error("Server error occurred for gem {0}, version {1}")]
     ServerError(String, String),
-    #[error("Unknown error occurred for gem `{0}`, version `{1}`")]
+    #[error("Unknown error occurred for gem {0}, version {1}")]
     UnknownError(String, String),
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 ///
 /// Errors enum, it required for retry failed requests
-/// 
+///
 #[derive(Error, Debug)]
 pub(crate) enum FetchPackageError {
     #[error("Could not send request for gem {0} version {1}")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,22 @@
+use thiserror::Error;
+
+///
+/// Errors enum, it required for retry failed requests
+/// 
+#[derive(Error, Debug)]
+pub(crate) enum FetchPackageError {
+    #[error("Could not send request for `{0}` for gem `{1}`")]
+    SendRequestError(String, String),
+    #[error("Could not receive response text for `{0}` for gem `{1}`")]
+    ResponseTextError(String, String),
+    #[error("Could not find version `{0}` for gem `{1}`")]
+    VersionNotFound(String, String),
+    #[error("Gem not found: `{0}`, version `{1}`")]
+    PackageNotFound(String, String),
+    #[error("Client error occurred for gem `{0}`, version `{1}`")]
+    ClientError(String, String),
+    #[error("Server error occurred for gem `{0}`, version `{1}`")]
+    ServerError(String, String),
+    #[error("Unknown error occurred for gem `{0}`, version `{1}`")]
+    UnknownError(String, String),
+}

--- a/src/gem.rs
+++ b/src/gem.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use reqwest::get;
+use reqwest_middleware::ClientWithMiddleware;
 use serde::{Deserialize, Serialize};
 
 pub(crate) mod licenses;
@@ -40,11 +40,14 @@ type GemfileItem<'a> = (&'a str, &'a str, Option<&'a str>);
 /// If all ok, this function returns Gemspec struct, which serializable
 /// to bom.json format
 ///
-pub(crate) async fn get_gem(gem_source: GemfileItem<'_>) -> Result<Gemspec> {
+pub(crate) async fn get_gem(
+    client: &ClientWithMiddleware,
+    gem_source: GemfileItem<'_>,
+) -> Result<Gemspec> {
     let (name, version, _) = gem_source;
     let url = format!("https://rubygems.org/api/v1/versions/{name}.json");
 
-    let response = get(url).await?;
+    let response = client.get(url).send().await?;
     let status = response.status();
 
     let result: Result<Gemspec> = match status.as_u16() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use reqwest_middleware::ClientWithMiddleware;
 mod bom_se;
 mod bundler;
 mod config;
+mod errors;
 mod gem;
 
 const CONCURRENT_REQUESTS: usize = 50;
@@ -36,8 +37,8 @@ async fn main() -> Result<()> {
 // to make requests and fetch all gems info from rubygems.org
 //
 type GemspecResultsPartition = (
-    Vec<Result<gem::Gemspec, anyhow::Error>>,
-    Vec<Result<gem::Gemspec, anyhow::Error>>,
+    Vec<Result<gem::Gemspec, errors::FetchPackageError>>,
+    Vec<Result<gem::Gemspec, errors::FetchPackageError>>,
 );
 async fn fetch_gems_info(
     client: &ClientWithMiddleware,
@@ -50,7 +51,7 @@ async fn fetch_gems_info(
             gem::get_gem(&client, source_info).await
         })
         .buffer_unordered(CONCURRENT_REQUESTS)
-        .collect::<Vec<Result<gem::Gemspec, anyhow::Error>>>()
+        .collect::<Vec<Result<gem::Gemspec, errors::FetchPackageError>>>()
         .await;
 
     let (successes, errors): GemspecResultsPartition =

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ async fn fetch_gems_info(
     let gem_specs_results = stream::iter(specs)
         .map(|source| async move {
             let source_info = source.get_source();
-            gem::get_gem(&client, source_info).await
+            gem::get_gem(client, source_info).await
         })
         .buffer_unordered(CONCURRENT_REQUESTS)
         .collect::<Vec<Result<gem::Gemspec, errors::FetchPackageError>>>()


### PR DESCRIPTION
Sometimes when application polls [rubygems.org](https://rubygems.org) some requests failed and it causes incorrect building of `bom.json` file. This PR add retry middleware for `reqwest` `get` requests with custom policy of retrying. 