### PR TITLE
Try to fix broken CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: cargo install cargo-audit --locked
       - run: make audit
   deny:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Try to fix broken CI:
```
cargo audit
error: no such command: `audit`

	Did you mean `add`?

	View all installed commands with `cargo --list`
	Find a package to install `audit` with `cargo search cargo-audit`
make: *** [Makefile:2[8](https://github.com/EvgeniyRRU/cyclonedx-rs-gem/actions/runs/12762257849/job/35570599013#step:3:9): audit] Error 101
Error: Process completed with exit code 2.
```